### PR TITLE
Monk: Add Monk Kit on nod branch

### DIFF
--- a/Dockerfile.redirect-server
+++ b/Dockerfile.redirect-server
@@ -1,0 +1,14 @@
+FROM golang:1.20 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd/main.go .
+COPY pkg/ ./pkg/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o redirect-server .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /app/redirect-server .
+EXPOSE 8080
+CMD ["./redirect-server"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO rrs
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,30 @@
+namespace: rrs
+
+redirect-server:
+  defines: runnable
+  metadata:
+    name: redirect-server
+    description: >-
+      A simple redirect server that pranks users by redirecting traffic to a
+      rickroll, except for Discord/Slack previews.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    redirect-server:
+      image: env-2161.registry.local/redirect-server:nod-e3d88e2
+      build: .
+      dockerfile: Dockerfile.redirect-server
+  services:
+    http-server:
+      description: HTTP server listening on this port
+      container: redirect-server
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - rrs/redirect-server


### PR DESCRIPTION
# Containerization and Deployment Configuration for Redirect Server

## Summary of Changes
I have successfully containerized the redirect server application and prepared it for deployment. Below are the key changes and additions:

- **Dockerfile**: Created a Dockerfile (`Dockerfile.redirect-server`) to build the Go application into a lightweight Docker image based on Alpine Linux. The Dockerfile copies the necessary Go files, builds the binary, and sets up the container to run the redirect-server on port 8080.
- **Monk Configuration**: Added a `monk.yaml` file containing the Monk.io configuration for the application, along with a `MANIFEST` file listing all files with Monk configurations.
- **Service Analysis**: Mapped the services and confirmed that the application is a self-contained Go application that redirects traffic to a rickroll URL, with exceptions for Discord/Slack previews. No third-party services like databases are used by the application.

## Issues Encountered
During the process, I encountered an issue with the initial Dockerfile build. The error was related to a missing package during the Go build process. I resolved this by ensuring that the entire 'pkg' directory was copied into the Docker image, which allowed the Dockerfile to build successfully.

## Instructions for Deployment
The application is now ready for deployment. The only step remaining is to merge this PR, and the application will be redeployed on each subsequent push. No further configuration is required since the application does not use any environment variables or connections to external services.

Please review the changes and proceed with merging if everything is in order.