### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO rrs
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,47 @@
+namespace: rrs
+
+redirect-server:
+  defines: runnable
+  metadata:
+    name: redirect-server
+    description: >-
+      A Go-based server that redirects traffic to a rickroll, with exceptions
+      for Discord/Slack previews.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    redirect-server:
+      image: env-3702.registry.local/redirect-server:master-c6c9666
+      build: .
+      dockerfile: ./Dockerfile
+  services:
+    http-server-port:
+      description: HTTP server port
+      container: redirect-server
+      port: $host
+      host-port: $host
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables:
+    host:
+      env: HOST
+      type: string
+      value: 8080
+      description: The host and port on which the server runs
+    rickroll-url:
+      env: RICKROLL_URL
+      type: string
+      value: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+      description: The URL to which traffic is redirected
+    preview-user-agents:
+      env: PREVIEW_USER_AGENTS
+      type: string
+      value: Slackbot,Discordbot
+      description: >-
+        Comma-separated list of user agents for which the server behaves
+        differently
+
+stack:
+  defines: group
+  members:
+    - rrs/redirect-server


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Redirect Server

## Changes Made

- **Containerization**: I have successfully containerized the redirect server using a Dockerfile. The server is implemented in Go and is designed to redirect traffic to a rickroll, with exceptions for Discord/Slack previews. The Dockerfile uses a multi-stage build with `golang:1.20-alpine` as the builder and `scratch` for the final image, exposing port 8080.
- **Configuration**: After a thorough review, I confirmed that the server is self-contained and does not require any external dependencies like databases. No additional configuration files or environment variables are needed for the basic operation of the server as it is designed to run as a standalone HTTP server.
- **Monk.io Integration**: I added `monk.yaml` and `MANIFEST` files to integrate with Monk.io, ensuring the application can be deployed using Monk's platform.

## Environment Variables

- Identified three environment variables required by the server: `HOST`, `RICKROLL_URL`, and `PREVIEW_USER_AGENTS`. These are used to configure the server's host and port, the redirection URL, and a list of user agents for previews, respectively.

## Instructions for Deployment

- **Merge PR**: The application is ready for deployment. Merging this PR will ensure that the application is re-deployed on each subsequent push.
- **Runtime Configuration**: If needed, set the `HOST`, `RICKROLL_URL`, and `PREVIEW_USER_AGENTS` environment variables according to the deployment environment specifics.

## Conclusion

The redirect server is now fully containerized and ready for deployment with no external service dependencies. The Dockerfile and Monk.io configuration are in place, and the application can be deployed seamlessly on Monk's platform.