### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO rrs
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,30 @@
+namespace: rrs
+
+rrs:
+  defines: runnable
+  metadata:
+    name: rrs
+    description: >-
+      A redirect server that rickrolls visitors, with exceptions for
+      Discord/Slack previews.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    rrs:
+      image: env-3702.registry.local/rrs:master-c6c9666
+      build: .
+      dockerfile: Dockerfile
+  services:
+    http-server:
+      description: The HTTP server port for the rrs service.
+      container: rrs
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - rrs/rrs


### PR DESCRIPTION
# PR Description for Containerization and Deployment Configuration

## Containerization

I've successfully containerized the `rrs` application, which is a simple Go-based redirect server. The server is designed to redirect traffic to a rickroll URL, with exceptions for requests from Slack and Discord previews. Here's what I've done:

- Created a `Dockerfile` that uses a multi-stage build process to compile the Go application and then copies the binary into a minimal scratch image.
- Exposed port `8080` in the `Dockerfile`, which is the port the application listens on.
- Verified that the application starts correctly and listens on the expected port without any errors.

## Deployment Configuration

For the deployment configuration, I've added the necessary Monk.io configuration files:

- Added `monk.yaml` to define the Monk configuration for the application.
- Included a `MANIFEST` file to list all files containing Monk configurations.

## Summary

The application does not require any external services, databases, or environment variables. It operates with hardcoded values for the host address and URLs. The containerization process is complete, and the application is ready to be re-deployed on each subsequent push. There are no further actions required unless additional information about other services or configurations is provided.

To continue the work, simply merge this PR, and the application will be redeployed automatically.